### PR TITLE
v4.3.0向けのテーマ周り修正

### DIFF
--- a/app/javascript/styles/mods/compact-padding.scss
+++ b/app/javascript/styles/mods/compact-padding.scss
@@ -42,20 +42,6 @@
     flex-grow: 0;
   }
 
-  .notification-ungrouped, .notification-group {
-    padding: 8px;
-  }
-
-  .notification-ungrouped .status__content {
-      margin-inline-start: 0;
-      width: 100%;
-  }
-
-  .notification-ungrouped .status__action-bar {
-      margin-inline-start: 0;
-      width: 100%;
-  }
-
   .notification-group__icon {
       width: 24px;   
   }
@@ -64,4 +50,27 @@
       margin-bottom: 4px;
       padding-inline-start: 0;
   }
+
+  .notification-ungrouped, .notification-group {
+    padding: 8px;
+  }
+
+  .notification-ungrouped {
+    .attachment-list,
+    .audio-player,
+    .content-warning,
+    .filter-warning,
+    .hashtag-bar,
+    .media-gallery,
+    .more-from-author,
+    .picture-in-picture-placeholder,
+    .status-card,
+    .status__action-bar,
+    .status__content,
+    .video-player {
+        margin-inline-start: 0;
+        width: 100%;
+    }
+  }
+
 }

--- a/app/javascript/styles/mods/compact-padding.scss
+++ b/app/javascript/styles/mods/compact-padding.scss
@@ -41,4 +41,27 @@
   .status__action-bar__button-wrapper {
     flex-grow: 0;
   }
+
+  .notification-ungrouped, .notification-group {
+    padding: 8px;
+  }
+
+  .notification-ungrouped .status__content {
+      margin-inline-start: 0;
+      width: 100%;
+  }
+
+  .notification-ungrouped .status__action-bar {
+      margin-inline-start: 0;
+      width: 100%;
+  }
+
+  .notification-group__icon {
+      width: 24px;   
+  }
+
+  .notification-ungrouped__header {
+      margin-bottom: 4px;
+      padding-inline-start: 0;
+  }
 }

--- a/app/javascript/styles/mods/compact-padding.scss
+++ b/app/javascript/styles/mods/compact-padding.scss
@@ -37,4 +37,8 @@
   .notification__message {
     padding: 12px 12px 0;
   }
+
+  .status__action-bar__button-wrapper {
+    flex-grow: 0;
+  }
 }

--- a/app/javascript/styles/mods/compact-padding.scss
+++ b/app/javascript/styles/mods/compact-padding.scss
@@ -19,11 +19,16 @@
 
   .status__content {
     padding-top: 0;
+    padding-bottom: 0;
   }
 
   .status__action-bar {
-    margin-top: 6px;
+    margin-top: 12px;
     justify-content: flex-start;
+  }
+
+  .status .status-card {
+    margin-top: 12px;
   }
 
   .status .media-gallery {

--- a/app/javascript/styles/mods/compact-padding.scss
+++ b/app/javascript/styles/mods/compact-padding.scss
@@ -48,12 +48,13 @@
   }
 
   .notification-group__icon {
-      width: 24px;   
+    width: 24px;   
   }
 
   .notification-ungrouped__header {
-      margin-bottom: 4px;
-      padding-inline-start: 0;
+    margin-bottom: 0;
+    padding-inline-start: 0;
+    padding: 0 12px;
   }
 
   .notification-ungrouped, .notification-group {
@@ -73,8 +74,11 @@
     .status__action-bar,
     .status__content,
     .video-player {
-        margin-inline-start: 0;
-        width: 100%;
+      margin-inline-start: 0;
+      width: 100%;
+    }
+    .status {
+      padding: 6px 8px;
     }
   }
 

--- a/app/javascript/styles/mods/legacy-style.scss
+++ b/app/javascript/styles/mods/legacy-style.scss
@@ -79,4 +79,8 @@
         margin: 0 -8px;
         padding-top: 12px;
     }
+
+    .status__action-bar__button-wrapper {
+        flex-grow: 0;
+    }
 }

--- a/app/javascript/styles/mods/legacy-style.scss
+++ b/app/javascript/styles/mods/legacy-style.scss
@@ -79,8 +79,25 @@
         margin: 0 -8px;
         padding-top: 12px;
     }
-
     .status__action-bar__button-wrapper {
         flex-grow: 0;
+    }
+    .notification-ungrouped, .notification-group {
+        padding: 4px 4px 2px 4px;
+    }
+    .notification-ungrouped .status__content {
+        margin-inline-start: 0;
+        width: 100%;
+    }
+    .notification-ungrouped .status__action-bar {
+        margin-inline-start: 0;
+        width: 100%;
+    }
+    .notification-group__icon {
+        width: 24px;   
+    }
+    .notification-ungrouped__header {
+        margin-bottom: 4px;
+        padding-inline-start: 0;
     }
 }

--- a/app/javascript/styles/mods/legacy-style.scss
+++ b/app/javascript/styles/mods/legacy-style.scss
@@ -82,22 +82,31 @@
     .status__action-bar__button-wrapper {
         flex-grow: 0;
     }
-    .notification-ungrouped, .notification-group {
-        padding: 4px 4px 2px 4px;
-    }
-    .notification-ungrouped .status__content {
-        margin-inline-start: 0;
-        width: 100%;
-    }
-    .notification-ungrouped .status__action-bar {
-        margin-inline-start: 0;
-        width: 100%;
-    }
     .notification-group__icon {
         width: 24px;   
     }
     .notification-ungrouped__header {
         margin-bottom: 4px;
         padding-inline-start: 0;
+    }
+    .notification-ungrouped, .notification-group {
+        padding: 8px;
+    }
+    .notification-ungrouped {
+        .attachment-list,
+        .audio-player,
+        .content-warning,
+        .filter-warning,
+        .hashtag-bar,
+        .media-gallery,
+        .more-from-author,
+        .picture-in-picture-placeholder,
+        .status-card,
+        .status__action-bar,
+        .status__content,
+        .video-player {
+            margin-inline-start: 0;
+            width: 100%;
+        }
     }
 }

--- a/app/javascript/styles/mods/legacy-style.scss
+++ b/app/javascript/styles/mods/legacy-style.scss
@@ -4,9 +4,41 @@
         padding-left: 2.15em;
         padding-bottom: 0;
     }
-    .status {
+    .status__line {
+        display: none;
+    }
+    .status:not(.status--in-thread) {
         padding: 0.5em 0.5em 0.5em 4.75em;
         position: relative;
+    }
+    .status .status__info {
+        padding-bottom: 0.25em;
+    }
+    .status__content {
+        padding-bottom: 0;
+    }
+    .status--in-thread{
+        padding-top: 0.5em;
+    }
+    .status--in-thread .status__info {
+        padding-left: 3.25em;
+        padding-bottom: 0;
+    }
+    .status--in-thread .status__content {
+        padding-top: 0.25em;
+        padding-left: 3.25em;
+        margin-right: 4em;
+    }
+    .status--in-thread .status__content {
+      -webkit-margin-start: 0px;
+      margin-inline-start: 0px;
+      width: calc(100% - 3.5em);
+    }
+    .status__wrapper-direct .status--in-thread .status__avatar {
+        padding-top: 2em;
+    }
+    .status--in-thread .status__action-bar {
+        margin-left: 3.5em;
     }
     .status-reply {
         padding-top: 0.25em;
@@ -31,6 +63,18 @@
     .status .display-name:not(.detailed-status__display-name) {
         display: flex;
     }
+    .detailed-status {
+        padding-top: 0.25em;
+        padding-left: 0.75em;
+        padding-bottom: 0.5em;
+    }
+    .detailed-status .status__prepend {
+        margin-left: 1.75em;
+        margin-bottom: 0.5em;
+    }
+    .detailed-status__display-name {
+        margin-bottom: 0.5em;
+    }
     .detailed-status .status-card {
         padding: 0.25em;
     }
@@ -41,8 +85,11 @@
         padding-left: 0;
     }
     .status__action-bar {
-        margin-top: 0.25em;
+        margin-top: 12px;
         justify-content: flex-start;
+    }
+    .status .status-card {
+        margin-top: 12px;
     }
     .status .media-gallery, .detailed-status .status-card, .detailed-status__meta {
         margin-top: 0.5em;
@@ -56,8 +103,8 @@
     .muted {
         padding-top: 0.5em;
     }
-    .detailed-status__display-name {
-        margin-bottom: 0.5em;
+    .mods__announcements__item {
+        margin: 10px;   
     }
     .drawer__inner .navigation-bar, .drawer__inner .compose-form {
         padding: 10px;


### PR DESCRIPTION
- 「コンパクト」「旧バージョン風」のアクション（リプライ/ブースト/お気に入り/ブックマーク）ボタンが左詰めにならなくなっていた問題の修正
- 通知領域の全体的な間隔調整
- 「旧バージョン風」の通知カラムでリプライの表示が左に大きく空いていた問題の修正